### PR TITLE
chore(renovate-bot): remove schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,4 @@
   "prCreation": "not-pending",
   "labels": ["type: dependencies"],
   "dependencyDashboard": true,
-  "schedule": ["before 3am on Monday"],
-  "timezone": "Australia/Brisbane"
 }


### PR DESCRIPTION
as I now own my CI machines / deploy with GitHub Pages, I don't need to worry about bandwidth restrictions (Netlify... Travis CI...)